### PR TITLE
Disable APT unattended upgrades

### DIFF
--- a/provision/base.sh
+++ b/provision/base.sh
@@ -4,6 +4,9 @@
 echo '' | sudo add-apt-repository ppa:ondrej/php
 sudo DEBIAN_FRONTEND=noninteractive apt-get update
 
+# Remove unattended upgrades
+sudo DEBIAN_FRONTEND=noninteractive apt-get purge -y unattended-upgrades
+
 # Install common packages
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y imagemagick gettext subversion git
 


### PR DESCRIPTION
Disable/remove APT unattended upgrades to ensure that a Vagrant box isn't magically updated and no additional provisioning fails.